### PR TITLE
use resource-name-sanitizer

### DIFF
--- a/.snapshots/TestRefresh-if_object_has_long_name.yaml
+++ b/.snapshots/TestRefresh-if_object_has_long_name.yaml
@@ -4,8 +4,8 @@ items:
   - metadata:
       creationTimestamp: null
       labels:
-        some-label-key: random-70-character-objKey-cmFuZG9tLTcwLWNoYXJhY3Rlci1uYW1lCci1uYW1lC
-      name: random-70-character-objKey-cmFuZG9tLTcwLWNoYXJhY3Rlci-some-s
+        some-label-key: random-70-character-objkey-cmfuzg9tltcwlwnoyxjhy3rlci1uyw1lcci1uyw1lc
+      name: random-70-character-objkey-cmfuzg9tltcwlwnoyxjhy3rlci-some-s
       namespace: some-namespace
       ownerReferences:
         - apiVersion: v1
@@ -17,13 +17,13 @@ items:
     spec:
       selector:
         matchLabels:
-          some-label-key: random-70-character-objKey-cmFuZG9tLTcwLWNoYXJhY3Rlci1uYW1lCci1uYW1lC
+          some-label-key: random-70-character-objkey-cmfuzg9tltcwlwnoyxjhy3rlci1uyw1lcci1uyw1lc
       strategy: {}
       template:
         metadata:
           creationTimestamp: null
           labels:
-            some-label-key: random-70-character-objKey-cmFuZG9tLTcwLWNoYXJhY3Rlci1uYW1lCci1uYW1lC
+            some-label-key: random-70-character-objkey-cmfuzg9tltcwlwnoyxjhy3rlci1uyw1lcci1uyw1lc
         spec:
           containers:
             - image: some-deployment:some-commit-sha
@@ -34,7 +34,7 @@ items:
       creationTimestamp: null
       labels:
         some-label-key: "1"
-      name: random-70-character-name-cmFuZG9tLTcwLWNoYXJhY3Rlci1uYW1lCci1uY
+      name: random-70-character-name-cmfuzg9tltcwlwnoyxjhy3rlci1uy-f8d9db6b
       namespace: some-namespace
       ownerReferences:
         - apiVersion: v1

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/wantedly/resource-name-sanitizer v0.0.0-20211210090254-2558977bd7ef // indirect
 	golang.org/x/net v0.0.0-20211209124913-491a49abca63 // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
 	golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 // indirect

--- a/go.sum
+++ b/go.sum
@@ -239,6 +239,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stuart-warren/yamlfmt v0.1.2 h1:ojguhYdHpNWy62fLkrQtLFGAzrqFxVaU8f5Z0U8mkMI=
 github.com/stuart-warren/yamlfmt v0.1.2/go.mod h1:X5TuPH+hf4O0U1KBvNqygvHbvAnoi9Wyl9BbtPv8SZk=
+github.com/wantedly/resource-name-sanitizer v0.0.0-20211210090254-2558977bd7ef h1:CY3oLZo+4TqA06Z5V1ORJS9pWG+tUGKomwwjVQnO9b4=
+github.com/wantedly/resource-name-sanitizer v0.0.0-20211210090254-2558977bd7ef/go.mod h1:489R51g2vdMpWugfLm6ncruK4AL71J87anxjH7AimOs=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/refresh_test.go
+++ b/refresh_test.go
@@ -119,8 +119,8 @@ func TestRefresh(t *testing.T) {
 			initialState: nil,
 			objectList: refresh.ObjectList{
 				Items: []client.Object{
-					ut.GenDeployment("random-70-character-name-cmFuZG9tLTcwLWNoYXJhY3Rlci1uYW1lCci1uYW1lC==", map[string]string{labelKey: "1"}),
-					ut.GenDeployment("", map[string]string{labelKey: "random-70-character-objKey-cmFuZG9tLTcwLWNoYXJhY3Rlci1uYW1lCci1uYW1lC"}),
+					ut.GenDeployment("random-70-character-name-cmfuzg9tltcwlwnoyxjhy3rlci1uyw1lcci1uyw1lc==", map[string]string{labelKey: "1"}),
+					ut.GenDeployment("", map[string]string{labelKey: "random-70-character-objkey-cmfuzg9tltcwlwnoyxjhy3rlci1uyw1lcci1uyw1lc"}),
 				},
 				GroupVersionKind: gvk,
 				Identity:         labelGetter,


### PR DESCRIPTION
## Why
ref. #5 
Kubernetes has a limit for the length of the resource name.

we've created [resource-name-sanitizer](https://github.com/wantedly/resource-name-sanitizer) to sanitize name, so we can use it

## What

- use resource-name-sanitizer
- label name and resource name should be lowercase, so converted them to lower